### PR TITLE
feat(ui): enable alternate screen buffer for better UI experience

### DIFF
--- a/src/ui/cli.c
+++ b/src/ui/cli.c
@@ -71,9 +71,13 @@ static void set_vis_color(int band, int total_bands, float intensity) {
 void cli_init(void) {
     printf("\033[?25l");
     printf("\033[2J\033[H");
+    // switch to alternate screen
+    printf("\e[?1049h");
 }
 
 void cli_cleanup(void) {
+    // switch back to main screen
+    printf("\e[?10491");
     printf("\033[?25h");
     printf("\033[2J\033[H");
     printf(RESET);


### PR DESCRIPTION

Summary:
This commit enables the alternate screen buffer in the CLI interface, which
allows for a more immersive user experience by preventing the terminal from
scrolling and messing up the command history. This is particularly useful for
applications that require a full-screen interface, such as this :).

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/dexter-xD/rhythm/pull/1).
* #2
* #3
* __->__ #1